### PR TITLE
Added message creation event handling

### DIFF
--- a/src/main/java/io/mindustry/plugin/BotThread.java
+++ b/src/main/java/io/mindustry/plugin/BotThread.java
@@ -25,6 +25,7 @@ public class BotThread extends Thread {
         this.api.addMessageCreateListener(commandHandler);
         new ComCommands().registerCommands(commandHandler);
         new ServerCommands(data).registerCommands(commandHandler);
+        new MessageCreatedListeners(data).registerListeners(commandHandler);
     }
 
     public void run(){

--- a/src/main/java/io/mindustry/plugin/MessageCreatedListeners.java
+++ b/src/main/java/io/mindustry/plugin/MessageCreatedListeners.java
@@ -1,0 +1,16 @@
+package io.mindustry.plugin;
+
+import io.mindustry.plugin.discordcommands.DiscordCommands;
+import io.mindustry.plugin.discordcommands.MessageCreatedListener;
+import org.json.JSONObject;
+
+public class MessageCreatedListeners {
+    private final JSONObject data;
+
+    public MessageCreatedListeners(JSONObject data){
+        this.data = data;
+    }
+    public void registerListeners(DiscordCommands handler){
+        
+    }
+}

--- a/src/main/java/io/mindustry/plugin/discordcommands/DiscordCommands.java
+++ b/src/main/java/io/mindustry/plugin/discordcommands/DiscordCommands.java
@@ -2,6 +2,8 @@ package io.mindustry.plugin.discordcommands;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.javacord.api.event.message.MessageCreateEvent;
 import org.javacord.api.listener.message.MessageCreateListener;
@@ -10,7 +12,7 @@ import org.javacord.api.listener.message.MessageCreateListener;
 public class DiscordCommands implements MessageCreateListener {
     public final String commandPrefix = ".";
     private HashMap<String, Command> registry = new HashMap<>();
-
+    private Set<MessageCreatedListener> messageCreatedListenerRegistry = new HashSet<>();
     public DiscordCommands() {
         // stuff
     }
@@ -31,10 +33,19 @@ public class DiscordCommands implements MessageCreateListener {
         registry.put(forcedName.toLowerCase(), c);
     }
     /**
+     * Register a method to be run when a message is created.
+     * @param listener MessageCreatedListener to be run when a message is created.
+     */
+    public void registerOnMessage(MessageCreatedListener listener) {
+        messageCreatedListenerRegistry.add(listener);
+    }
+    /**
      * Parse and run a command
      * @param event Source event associated with the message
      */
     public void onMessageCreate(MessageCreateEvent event) {
+        for(MessageCreatedListener listener: messageCreatedListenerRegistry) listener.run(event);
+
         String message = event.getMessageContent();
         if (!message.startsWith(commandPrefix)) return;
         String[] args = message.split(" ");

--- a/src/main/java/io/mindustry/plugin/discordcommands/MessageCreatedListener.java
+++ b/src/main/java/io/mindustry/plugin/discordcommands/MessageCreatedListener.java
@@ -1,0 +1,9 @@
+package io.mindustry.plugin.discordcommands;
+
+import org.javacord.api.event.message.MessageCreateEvent;
+
+public abstract class MessageCreatedListener {
+    public void run(MessageCreateEvent messageCreateEvent){
+
+    }
+}


### PR DESCRIPTION
Lets you register a listener for raw message events. Useful for replying to messages without any command triggered (Like, say, posting a reminder to read pins in map-submissions, say? 😉).